### PR TITLE
fix: AP受信時、tag配列にのみ存在するハッシュタグをテキストに補完

### DIFF
--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -6,6 +6,7 @@
 import { forwardRef, Inject, Injectable } from '@nestjs/common';
 import { In } from 'typeorm';
 import * as Redis from 'ioredis';
+import * as mfm from 'mfm-js';
 import { DI } from '@/di-symbols.js';
 import type { PollsRepository, EmojisRepository, MiMeta } from '@/models/_.js';
 import type { Config } from '@/config.js';
@@ -24,6 +25,8 @@ import { UtilityService } from '@/core/UtilityService.js';
 import { bindThis } from '@/decorators.js';
 import { checkHttps } from '@/misc/check-https.js';
 import { IdentifiableError } from '@/misc/identifiable-error.js';
+import { extractHashtags } from '@/misc/extract-hashtags.js';
+import { normalizeForSearch } from '@/misc/normalize-for-search.js';
 import { getOneApId, getApId, getOneApHrefNullable, validPost, isEmoji, getApType } from '../type.js';
 import { ApLoggerService } from '../ApLoggerService.js';
 import { ApMfmService } from '../ApMfmService.js';
@@ -196,7 +199,9 @@ export class ApNoteService {
 		// PieFed等、contentにハッシュタグを含めずtag配列にのみ格納するサーバーへの対応
 		if (apHashtags.length > 0) {
 			const currentText = text ?? '';
-			const missingTags = apHashtags.filter(tag => !currentText.includes(`#${tag}`));
+			const tokens = currentText ? mfm.parse(currentText) : [];
+			const existingTags = new Set(extractHashtags(tokens).map(t => normalizeForSearch(t)));
+			const missingTags = apHashtags.filter(tag => !existingTags.has(normalizeForSearch(tag)));
 			if (missingTags.length > 0) {
 				const hashtagText = missingTags.map(tag => `#${tag}`).join(' ');
 				text = currentText ? `${currentText}\n\n${hashtagText}` : hashtagText;

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -192,6 +192,17 @@ export class ApNoteService {
 			text = this.apMfmService.htmlToMfm(note.content, note.tag);
 		}
 
+		// tag配列にあるがテキストに含まれないハッシュタグを補完
+		// PieFed等、contentにハッシュタグを含めずtag配列にのみ格納するサーバーへの対応
+		if (apHashtags.length > 0) {
+			const currentText = text ?? '';
+			const missingTags = apHashtags.filter(tag => !currentText.includes(`#${tag}`));
+			if (missingTags.length > 0) {
+				const hashtagText = missingTags.map(tag => `#${tag}`).join(' ');
+				text = currentText ? `${currentText}\n\n${hashtagText}` : hashtagText;
+			}
+		}
+
 		const poll = await this.apQuestionService.extractPollFromQuestion(note, resolver).catch(() => undefined);
 
 		//#region Contents Check


### PR DESCRIPTION
## 背景

[PieFed](https://piefed.social/)等、ActivityPub対応のリンクアグリゲーター/フォーラムとの連合において、ハッシュタグが表示されない現象が報告されています。

### 原因

ActivityPubの仕様上、ハッシュタグは以下の2箇所に含まれ得ます：

1. **`content`（HTML本文）** — `<a>` タグとして本文中に記述
2. **`tag` 配列** — `{"type": "Hashtag", "name": "#example"}` として構造化データで記述

MastodonなどのサーバーはHTMLの`content`にもハッシュタグリンクを含めますが、PieFed等は`tag`配列にのみハッシュタグを格納し、`content`には含めない実装になっています。

Misskeyの既存実装では：
- `tag`配列から`extractApHashtags()`でハッシュタグを抽出 → `note.tags`に格納（検索・トレンド用） ✅
- `htmlToMfm(content, tag)`でHTML本文をMFMに変換 → `note.text`（ユーザーに表示） ❌

`htmlToMfm`はHTML内の`<a>`タグのテキストが`tag`配列のハッシュタグ名と一致するか確認しますが、そもそもHTML内にハッシュタグのリンクが存在しない場合、テキストにハッシュタグが含まれません。

結果として、`note.tags`にはハッシュタグが正しく格納される（検索には引っかかる）ものの、**ユーザーに表示されるテキストにはハッシュタグが現れない**という現象が発生します。

## 変更内容

`ApNoteService.createNote()`でテキスト変換後、`tag`配列に含まれるがテキストに存在しないハッシュタグを末尾に補完する処理を追加しました。

### 安全性

- **Mastodon等**（contentにハッシュタグリンクを含むサーバー）: `htmlToMfm`で既にテキストに`#tag`が含まれるため、何も追加されません
- **PieFed等**（tag配列にのみハッシュタグがあるサーバー）: 不足分のみ末尾に追加されます

## テスト計画

- [x] PieFedからのハッシュタグ付き投稿が正しく表示されることを確認
- [x] Mastodon等、既存サーバーからの投稿でハッシュタグが重複しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)