### PR TITLE
fix: スパムブロック時の例外をIdentifiableErrorに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2025.12.2+2",
+	"version": "2025.12.2+3",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/backend/src/core/activitypub/models/ApNoteService.ts
+++ b/packages/backend/src/core/activitypub/models/ApNoteService.ts
@@ -313,7 +313,7 @@ export class ApNoteService {
 
 		// block spam
 		if ((actor.host != null) && (actor.followersCount == 0) && (1 < noteAudience.mentionedUsers.length)) {
-			throw new Error(`Spam blocked: followersCount:${actor.followersCount} mentionedUsers:${noteAudience.mentionedUsers.length}`);
+			throw new IdentifiableError('d3e2e185-4469-4e4a-985c-943640de7d72', `Spam blocked: remote user with no followers mentioned ${noteAudience.mentionedUsers.length} users`);
 		}
 
 		try {


### PR DESCRIPTION
## Summary
- AP受信時のスパムブロックで使用していた汎用`Error`を`IdentifiableError`に変更
- 従来は「Internal error occurred」としか表示されず原因特定が困難だった
- エラーIDによる識別と、より明確なメッセージにより原因把握が容易になる

## Background
リモートユーザー（フォロワー0人）が2人以上にメンションした投稿をスパムとしてブロックする独自フィルターにおいて、汎用的な`Error`を使っていたため、ユーザーに表示されるエラーが不親切だった。

## Test plan
- [x] フォロワー0のリモートユーザーが複数メンション付き投稿を送信した場合、IdentifiableErrorとしてブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)