### PR TITLE
Fix: ギャラリー編集画面のモバイルスクロール不具合を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.3.1+0",
+	"version": "2026.3.1+1",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/frontend/src/pages/gallery/edit.root.vue
+++ b/packages/frontend/src/pages/gallery/edit.root.vue
@@ -4,7 +4,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<PageWithHeader :actions="headerActions" :tabs="headerTabs">
 	<div class="_spacer" style="--MI_SPACER-w: 800px; --MI_SPACER-min: 16px; --MI_SPACER-max: 32px;">
 		<MkInput v-model="title">
 			<template #label>{{ i18n.ts.title }}</template>
@@ -31,11 +30,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<MkButton v-if="props.post != null" danger @click="del"><i class="ti ti-trash"></i> {{ i18n.ts.delete }}</MkButton>
 		</div>
 	</div>
-</PageWithHeader>
 </template>
 
 <script lang="ts" setup>
-import { computed, watch, ref } from 'vue';
+import { ref } from 'vue';
 import * as Misskey from 'misskey-js';
 import MkButton from '@/components/MkButton.vue';
 import MkInput from '@/components/MkInput.vue';
@@ -113,9 +111,6 @@ async function del() {
 	router.push('/gallery');
 }
 
-const headerActions = computed(() => []);
-
-const headerTabs = computed(() => []);
 </script>
 
 <style lang="scss" scoped>

--- a/packages/frontend/src/pages/gallery/edit.vue
+++ b/packages/frontend/src/pages/gallery/edit.vue
@@ -4,14 +4,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<MkSuspense v-slot="{ result }" :p="_fetch_">
-	<XRoot :post="result"/>
-</MkSuspense>
+<PageWithHeader>
+	<MkSuspense v-slot="{ result }" :p="_fetch_">
+		<XRoot :post="result"/>
+	</MkSuspense>
+</PageWithHeader>
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
-import * as Misskey from 'misskey-js';
 import XRoot from './edit.root.vue';
 import { misskeyApi } from '@/utility/misskey-api.js';
 import { i18n } from '@/i18n.js';


### PR DESCRIPTION
## Summary
- ギャラリー編集画面（新規・既存とも）がモバイルで上下スクロールできない問題を修正
- `MkSuspense` がフラグメントコンポーネントのため、Vue 3 の attribute fallthrough が機能せず、`.content` クラス（`flex: 1; min-height: 0`）が適用されなかったことが原因
- `PageWithHeader` を `edit.vue` のルート要素に移動し、`MkSuspense` をその内部に配置

## Test plan
- [x] モバイル（スマホ実機）でギャラリー新規作成画面を開き、スワイプで上下スクロールできることを確認
- [x] モバイルで既存ギャラリーの編集画面を開き、同様にスクロールできることを確認
- [x] PC表示でもギャラリー編集画面が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)