### PR TITLE
cleanRemoteNotesのminIdクエリにtimeoutハンドリングを追加

### DIFF
--- a/packages/backend/src/queue/processors/CleanRemoteNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/CleanRemoteNotesProcessorService.ts
@@ -104,15 +104,30 @@ export class CleanRemoteNotesProcessorService {
 		}
 		const removalCriteria = removalCriteriaList.join(' AND ');
 
-		const minId = (await this.notesRepository.createQueryBuilder('note')
-			.select('MIN(note.id)', 'minId')
-			.where({
-				id: LessThan(initialConfig.newestLimit),
-				userHost: Not(IsNull()),
-				replyId: IsNull(),
-				renoteId: IsNull(),
-			})
-			.getRawOne<{ minId?: MiNote['id'] }>())?.minId;
+		let minId: MiNote['id'] | undefined;
+		try {
+			minId = (await this.notesRepository.createQueryBuilder('note')
+				.select('MIN(note.id)', 'minId')
+				.where({
+					id: LessThan(initialConfig.newestLimit),
+					userHost: Not(IsNull()),
+					replyId: IsNull(),
+					renoteId: IsNull(),
+				})
+				.getRawOne<{ minId?: MiNote['id'] }>())?.minId;
+		} catch (e) {
+			if (e instanceof QueryFailedError && e.driverError?.code === '57014') {
+				this.logger.warn('minId query timed out, skipping this run...');
+				return {
+					deletedCount: 0,
+					oldest: null,
+					newest: null,
+					skipped: false,
+					transientErrors: 0,
+				};
+			}
+			throw e;
+		}
 
 		if (!minId) {
 			this.logger.info('No notes can possibly be deleted, skipping...');


### PR DESCRIPTION
## Summary

- minIdクエリがtry/catchで囲まれておらず、statement_timeoutでジョブ全体がcrashしていたバグを修正
- タイムアウト時はスキップして次回再試行する

## 背景

- statement_timeout=10sの環境で、980万行のnoteテーブルに対するminIdクエリがタイムアウト
- バッチクエリの自動縮小機能に到達できずジョブが失敗していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)