### PR TITLE
cleanRemoteNotesのDELETEクエリにtimeoutハンドリング追加

### DIFF
--- a/packages/backend/src/queue/processors/CleanRemoteNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/CleanRemoteNotesProcessorService.ts
@@ -325,6 +325,10 @@ export class CleanRemoteNotesProcessorService {
 					if (e instanceof QueryFailedError && e.driverError?.code?.startsWith('23')) {
 						transientErrors++;
 						job.log(`Error deleting notes: ${e} (transient race condition?)`);
+					} else if (e instanceof QueryFailedError && e.driverError?.code === '57014') {
+						// Statement timeout on DELETE. End this run gracefully; the next run will retry.
+						job.log(`DELETE query timed out (${deletableNoteIds.length} notes), ending this run...`);
+						break;
 					} else {
 						throw e;
 					}


### PR DESCRIPTION
## Summary

- DELETE クエリのcatchがclass 23(integrity violation)専用で、statement_timeoutが未ハンドリングだった
- タイムアウト時はこのrunを終了し、次回実行で再試行

🤖 Generated with [Claude Code](https://claude.com/claude-code)