### PR TITLE
fix: cleanRemoteNotesのDELETEにローカルstatement_timeoutを適用

### DIFF
--- a/packages/backend/src/queue/processors/CleanRemoteNotesProcessorService.ts
+++ b/packages/backend/src/queue/processors/CleanRemoteNotesProcessorService.ts
@@ -306,7 +306,18 @@ export class CleanRemoteNotesProcessorService {
 			const deletableNoteIds = noteIds.filter(result => result.isRemovable).map(result => result.id);
 			if (deletableNoteIds.length > 0) {
 				try {
-					await this.notesRepository.delete(deletableNoteIds);
+					// Run DELETE under a relaxed statement_timeout. The global 10s timeout
+					// protects interactive API queries but is not viable for deleting large
+					// remote note trees; 5 minutes is enough for minimum-limit batches even
+					// on servers with millions of candidate rows.
+					await this.db.transaction(async (manager) => {
+						await manager.query("SET LOCAL statement_timeout = '300s'");
+						await manager.createQueryBuilder()
+							.delete()
+							.from(this.notesRepository.metadata.target)
+							.whereInIds(deletableNoteIds)
+							.execute();
+					});
 
 					for (const id of deletableNoteIds) {
 						const t = this.idService.parse(id).date.getTime();


### PR DESCRIPTION
## 背景

ダイスキー本番（~980万行のnoteテーブル）で `cleanRemoteNotes` を有効化した後、#411〜#414 の一連の修正を経て 2026-04-13 にようやく crash せず完走するようになった。しかし実際の削除件数は **35件/日** と極めて少なく、ジョブログには以下のパターンが残っていた:

```
Deleted 1081 notes; 4606ms
Deleted 500 notes; 2967ms
...
DELETE query timed out (1783 notes), reducing limit to 25 and retrying...
Deleted 91 notes; 1968ms
Deleted 78 notes; 1895ms
DELETE query timed out (1777 notes), reducing limit to 10 and retrying...
Deleted 14 notes; 2168ms
Deleted 11 notes; 2164ms
DELETE query timed out at minimum limit (1758 notes), ending this run...
```

`currentLimit` を minimumLimit (10) まで縮小しても DELETE が statement_timeout (10s) に間に合わず、#414 の縮小リトライ後に `break` で終了していた。グローバル `statement_timeout = 10s` は対話API保護のため必要だが、巨大なリモートノートツリーの DELETE には事実上通らない。削除が必要ないサーバーでは動くが、本当に必要な規模のサーバーでは削除が進まないという逆説的な状態。

## 変更

DELETE クエリをトランザクションで包み、`SET LOCAL statement_timeout = '300s'` で削除パスだけタイムアウトを緩和する。`SET LOCAL` はトランザクション終了時に自動復帰するため、他のクエリパスには影響しない。

## 効果（期待値）

- minimumLimit (10) バッチでも確実に DELETE が通るようになり、#414 の縮小リトライ→早期break経路に入らない
- candidate walk の cursor がより深くまで進み、1回のジョブで削除できる件数が桁違いに増える見込み
- 1日あたりの削除ペースが改善し、現実的な期間でのクリーンアップ完了が可能に

## リスク

- 削除中はトランザクションがノート行のロックを保持するが、削除バッチは数十〜数千件単位で短期間のため実運用への影響は軽微
- 300秒は十分余裕を持った値。もし不足する規模があれば別途調整