### PR TITLE
fix: drive_file に root files 用 partial index を追加

### DIFF
--- a/packages/backend/migration/1777624793874-DriveFileUserRootIdDescIndex.js
+++ b/packages/backend/migration/1777624793874-DriveFileUserRootIdDescIndex.js
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class DriveFileUserRootIdDescIndex1777624793874 {
+    name = 'DriveFileUserRootIdDescIndex1777624793874'
+
+    async up(queryRunner) {
+        // PG プランナーが /api/drive/files の root クエリで PK 降順 backward scan を選び、
+        // ヘビーユーザーが root 直下のファイルをフォルダに移動して疎にすると statement_timeout
+        // (10s) でクエリが落ちる問題への対処。partial index で root クエリを直接拾わせる。
+        // 本番 (daisskey) には先に SQL 直適用済みのため IF NOT EXISTS で衝突回避。
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_drive_file_user_root_id_desc" ON "drive_file" ("userId", "id" DESC) WHERE "folderId" IS NULL`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_drive_file_user_root_id_desc"`);
+    }
+}


### PR DESCRIPTION
## 背景

capsicum ユーザー報告: https://misskey.delmulin.com/notes/alpx848h0n

ダイスキーのドライブ最大ヘビーユーザーが「ファイルをフォルダに片付けたら drive 全体が読めなくなった」と報告。capsicum 側のバグかと思いきや、Misskey サーバー側の `/api/drive/files` が HTTP 500 を返していた。

## 原因

PG プランナーが、

```sql
SELECT * FROM drive_file
WHERE "userId" = ? AND "folderId" IS NULL
ORDER BY id DESC LIMIT 20
```

に対して PK の id 降順 backward scan + フィルタを選ぶ。複合 index `IDX_55720b33a61a7c806a8215b825 (userId, folderId, id)` は存在するが採用されない。

ユーザーがファイルをフォルダに移動して root 直下を疎にすると、LIMIT 20 を満たすために 190 万行を後ろから舐めることになり、`statement_timeout (10s)` でクエリが落ちて 500 になる。

```
EXPLAIN ANALYZE: 29,500 ms
Index Scan Backward using "PK_43ddaaaf18c9e68029b7cbb032e" on drive_file
  (cost=0.43..1508.87 rows=20) (actual time=31..29500 rows=5)
  Filter: ("folderId" IS NULL) AND ("userId" = ?)
  Rows Removed by Filter: 1947187
```

WebUI でも同じく 500 を踏むが、こちらは空配列扱いされて「フォルダだけ表示」と縮退する。capsicum はエラーとして拾うので可視化された。

## 対処

partial index を追加して root クエリを直接拾わせる：

```sql
CREATE INDEX "IDX_drive_file_user_root_id_desc"
ON "drive_file" ("userId", "id" DESC) WHERE "folderId" IS NULL;
```

## 効果（daisskey 本番、SQL 直接適用済み）

| 指標 | Before | After |
|---|---|---|
| 実行時間（root 5 件 / 全 1.95M 行） | 29,500 ms（500） | **0.7 ms** |
| プラン | PK 降順 backward scan | `IDX_drive_file_user_root_id_desc` Index Scan |
| インデックスサイズ | — | 75 MB |

## 書き込みコスト

partial index のため `"folderId" IS NULL` の行のみインデックス更新が走る:

| 操作 | コスト |
|---|---|
| INSERT（root にアップロード） | 通常 index と同じ |
| INSERT（フォルダ指定アップロード） | **更新なし** |
| UPDATE folderId NULL → 非NULL（フォルダに移動） | 1 削除 |
| UPDATE folderId 非NULL → 非NULL（フォルダ間移動） | **更新なし** |
| UPDATE folderId 非NULL → NULL | 1 挿入 |
| DELETE root のファイル | 1 削除 |

ドライブの書き込みは秒間数件レベルなので無視できる範囲。

## 適用済み

- ✅ daisskey 本番: SQL 直接適用済み（2026-05-01 17:30 頃）。マイグレーションは `IF NOT EXISTS` で衝突回避
- ⏳ dev23 / きゅあすきー: 本 PR マージ後の `pnpm run migrate` で反映

## 観測ログ

本日 (2026-05-01) 同症状を踏んでいたユーザー: 少なくとも 2 名 / 5 イベント。capsicum と WebUI 双方から発生。

```
07:06:26  capsicum (Dart/3.11)              500
07:06:38  capsicum (Dart/3.11)              500
07:06:50  capsicum (Dart/3.11)              500
07:08:08  WebUI (Mozilla/Android)           500
12:27:04  capsicum (Dart/3.11)              500  ← 報告投稿の元
12:27:33  capsicum (Dart/3.11)              500
16:21:14  WebUI (Mozilla/Android)           500
```

index 適用後は 500 ゼロ。

## 関連

- chubo2 infra-note にも記録
- capsicum 側で `DriveContentsNotifier.build()` の AsyncError が Sentry に届いていない件は別 issue として起票予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)