### PR TITLE
chore: バージョンを 2026.7.0+3 にバンプ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.7.0+0",
+	"version": "2026.7.0+3",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## やったこと

ルート `package.json` の版を `2026.7.0+0` → `2026.7.0+3` にバンプする。

`+` 以降はこのフォーク独自の連番で、**上流追従でない変更を入れるたびに 1 つ進める**運用
（`c220ba9a29` = 2026.5.0+1、`bd947f4729` = 2025.12.2+3 等）。ところが 2026.7.0 の追従マージ
`9d6b7d05de` で `+0` に戻して以降、独自変更が 3 つ入っているのに**バンプが漏れていた**。
本番の版表示が `+0` のままで、どのフォーク改変まで載った build なのかが判別できない。

## 数えかた

| 版 | 変更 |
| --- | --- |
| +1 | `dcb8149d71` fix: デフォルトタグ追記の条件が反転していた |
| +2 | `99b7ca09a9` fix: cleanRemoteNotes の起動を 2:00 に戻す |
| +3 | #420 feat: タグセットウィジェットに次回放送日を表示する（`eb92a86223`..`4837a6ba81`） |

#421（`docs/CLAUDE.md` の追加）は**挙動を変えないので数えていない**。

## 変更範囲

ルート `package.json` の 1 行のみ。過去のバンプ実績（`c220ba9a29` / `bd947f4729`）に倣った。
⚠ `packages/misskey-js/package.json` の `2026.7.0` は**上流管理なので触っていない**。

## 検証

- `node -e "require('./package.json')"` → パース OK、`version` が `2026.7.0+3` になることを確認
- ⚠ この環境は `node_modules` を持たないため `pnpm lint` は回せていない。ただし lint 対象
  （`.ts` / `.vue` / `.scss`）の変更は無く、locale / migration / entity / endpoint いずれも非該当

🤖 Generated with [Claude Code](https://claude.com/claude-code)
