### PR TITLE
fix: タグセットの「エア番組」を無条件で表示する (#424)

### DIFF
--- a/packages/frontend/src/widgets/WidgetTagset.vue
+++ b/packages/frontend/src/widgets/WidgetTagset.vue
@@ -103,10 +103,11 @@ const buildLabel = (p: Program, now: Date): string => {
 		label.push(`${dic.episodePrefix}${p.episode}${p.episode_suffix || dic.episodeSuffix}`);
 	}
 	if (p.subtitle) label.push(`「${p.subtitle}」`);
-	if (p.livecure) {
-		if (p.air) label.push(dic.air);
-		label.push(dic.livecure);
-	}
+	// air は livecure とは独立した軸（モロヘイヤ docs/api.md）。従属させると、下の
+	// user_tags 側（無条件）と食い違い、確認ダイアログで見た文字列と実際に送るタグが
+	// ズレる。capsicum / Mastodon フォークも無条件 (#424)
+	if (p.air) label.push(dic.air);
+	if (p.livecure) label.push(dic.livecure);
 	if (p.minutes) label.push(`${p.minutes}分`);
 	(p.extra_tags ?? []).forEach(tag => label.push(tag));
 	return label.join(' ');


### PR DESCRIPTION
Fixes #424

## なぜ

ラベル側の `air` が `livecure` に従属していた。`air: true` / `livecure: false` の枠で、
**ラベルに「エア番組」が出ないのに `user_tags` には入る**。確認ダイアログはこのラベルを再利用
するので、⚠ **ユーザーが見た文字列と、実際に送られるタグが一致しない**。

⚠⚠ **好みの問題ではなく実装漏れ。**`air` はモロヘイヤの仕様上 `livecure` とは独立した軸:

- モロヘイヤ [docs/api.md](https://github.com/pooza/mulukhiya-toot-proxy/blob/main/docs/api.md) — 「`air` … エア番組フラグ。**`true` で「エア番組」タグが付与される**」
- capsicum `compose_screen.dart` のコメント — 「air フラグ … は**独立した軸**」

## 3 クライアント × 2 軸の実測

⚠ **6 セル中、このフォークの表示ラベルだけが例外**だった:

| クライアント | 表示ラベル | 投稿に載るタグ |
| --- | --- | --- |
| [capsicum](https://github.com/pooza/capsicum) | `air` 無条件（`compose_screen.dart:4713`） | `air` 無条件（同 `:2451`） |
| [pooza/mastodon](https://github.com/pooza/mastodon) | `air` 無条件（`tagset_dropdown.tsx:107`） | `air` 無条件（`reducers/compose.js:437`） |
| **このフォーク** | 🔴 **`livecure` が真のときだけ** | `air` 無条件（`WidgetTagset.vue:186`） |

## 直し方

```diff
-	if (p.livecure) {
-		if (p.air) label.push(dic.air);
-		label.push(dic.livecure);
-	}
+	if (p.air) label.push(dic.air);
+	if (p.livecure) label.push(dic.livecure);
```

⚠⚠ **この 1 箇所で、クライアント間の食い違いと、同じファイル内のラベル vs タグ値の食い違いが
同時に解消する。**🔴 **逆向き（`air` を `livecure` 従属へ揃える）は 2 リポジトリ 3 箇所**になるので、
波及の小さいこちらを採った。

**並び順は変えていない。**`air` → `livecure` の順で、`user_tags` 側（`:186-187`）と同じ。

## 影響

- `livecure` が真の枠 — ⚠ **変化なし**（従来も `air` → `livecure` の順で出ていた）
- `air: true` / `livecure: false` の枠 — ラベルに「エア番組」が**出るようになる**。タグ側は元から
  入っていたので、**タグの内容は変わらない**。表示が実態に追いつくだけ

## 検証

`node_modules` が無い環境なので eslint / tsc はローカルで回していない（変更は SFC 内の 5 行で、
新しい識別子も型も増えていない）。CI の frontend-diagnostics に委ねる。

⚠ このフォークは番組表を読む 3 クライアントのひとつで、**書式が割れると利用者が番組表を
突き合わせられなくなる**（pooza/mastodon の `docs/CLAUDE.md`「番組表を読むクライアントは 3 つある」）。
今回はその揃え直し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
