### PR TITLE
chore: バージョンを 2026.7.0+4 にバンプ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.7.0+3",
+	"version": "2026.7.0+4",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## やったこと

ルート `package.json` の版を `2026.7.0+3` → `2026.7.0+4` にバンプする。#425 と同じ運用。

## 数えかた

`+` 以降はこのフォーク独自の連番で、**上流追従でない挙動変更を入れるたびに 1 つ進める**。

| 版 | 変更 |
| --- | --- |
| +4 | #427 `fix: タグセットの「エア番組」を無条件で表示する` (#424) |

⚠ **数えなかったもの**（#421 を数えなかったのと同じ基準 —— 挙動を変えないため）:

- #426 `fix: 追従で取り残された fluent-emojis の gitlink を消す`
- #429 `chore: 死んでいる診断系 workflow を削り、テスト設定を戻す` (#428)

## なぜ今か

⚠ **daisskey 本番（vulcan）は現在 `99b7ca09a9` で、`#419` 以降 11 コミットが未適用。**
次の適用でまとめて載る。#425 の趣旨（**本番の版表示で、どのフォーク改変まで載った build かを
判別する**）からすると、⚠⚠ **その適用より前にバンプが入っていないと意味がない。**
#419 / #424 は 2026-09-06 のニチアサまでに 3 クライアントを揃える件なので、その窓に乗る。

## 変更範囲

ルート `package.json` の 1 行のみ。⚠ `packages/misskey-js/package.json` の `2026.7.0` は
**上流管理なので触っていない**。

## 検証

- `node -e "console.log(require('./package.json').version)"` → `2026.7.0+4`（パース OK）
- ⚠ この環境は `node_modules` を持たないため `pnpm lint` は回せていない。lint 対象
  （`.ts` / `.vue` / `.scss`）の変更は無く、locale / migration / entity / endpoint いずれも非該当
- CI は `packages-private.yml` が走る（`package.json` が対象パスに入っているため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
