### PR TITLE
fix: followers 限定ノートのリプライ／メンション例外を noteUpdated でも尊重する (#422)

### DIFF
--- a/packages/backend/src/core/GlobalEventService.ts
+++ b/packages/backend/src/core/GlobalEventService.ts
@@ -132,6 +132,10 @@ type NoteStreamEventTypes = {
 		userId: MiNote['userId'];
 		visibility: MiNote['visibility'];
 		visibleUserIds: MiNote['visibleUserIds'];
+		// visibility が followers のときの例外判定 (自分の投稿へのリプライ / 自分へのメンション) に使う。
+		// Connection.onNoteStreamMessage を参照。
+		replyUserId: MiNote['replyUserId'];
+		mentions: MiNote['mentions'];
 		body: NoteEventTypes[key];
 	};
 };
@@ -387,6 +391,8 @@ export class GlobalEventService {
 			userId: note.userId,
 			visibility: note.visibility,
 			visibleUserIds: note.visibleUserIds,
+			replyUserId: note.replyUserId,
+			mentions: note.mentions,
 			body: value,
 		});
 	}

--- a/packages/backend/src/core/GlobalEventService.ts
+++ b/packages/backend/src/core/GlobalEventService.ts
@@ -134,8 +134,10 @@ type NoteStreamEventTypes = {
 		visibleUserIds: MiNote['visibleUserIds'];
 		// visibility が followers のときの例外判定 (自分の投稿へのリプライ / 自分へのメンション) に使う。
 		// Connection.onNoteStreamMessage を参照。
-		replyUserId: MiNote['replyUserId'];
-		mentions: MiNote['mentions'];
+		// ⚠ optional なのは、ローリング更新中に**この 2 つを積まない旧バージョンの producer が
+		// publish した payload**を受け取りうるため (pub/sub はプロセスを跨ぐ)。購読側で必ず不在を扱う。
+		replyUserId?: MiNote['replyUserId'];
+		mentions?: MiNote['mentions'];
 		body: NoteEventTypes[key];
 	};
 };

--- a/packages/backend/src/server/api/stream/Connection.ts
+++ b/packages/backend/src/server/api/stream/Connection.ts
@@ -222,9 +222,11 @@ export default class Connection {
 
 				const isFollower = Object.hasOwn(this.following, data.body.userId);
 				// 自分の投稿に対するリプライ
-				const isReplyToMe = data.body.replyUserId === meId;
+				// ⚠ 旧バージョンの producer が publish した payload には無いことがある (ローリング更新中)。
+				// 例外側が欠けても「フォロワーなら届く」までは維持する
+				const isReplyToMe = meId === data.body.replyUserId;
 				// 自分へのメンション
-				const isMentioningMe = data.body.mentions.includes(meId);
+				const isMentioningMe = data.body.mentions?.includes(meId) ?? false;
 
 				if (!isFollower && !isReplyToMe && !isMentioningMe) {
 					return;

--- a/packages/backend/src/server/api/stream/Connection.ts
+++ b/packages/backend/src/server/api/stream/Connection.ts
@@ -206,6 +206,8 @@ export default class Connection {
 
 	@bindThis
 	private async onNoteStreamMessage(data: GlobalEvents['note']['payload']) {
+		// This code must always be synchronized with Channel.isNoteVisibleForMe
+		// and the checks in QueryService.generateVisibilityQuery.
 		// 自分自身ではないかつ
 		if (data.body.userId !== this.user?.id) {
 			// 公開範囲が指名で自分が含まれてない
@@ -213,9 +215,20 @@ export default class Connection {
 				return;
 			}
 
-			// 公開範囲がフォロワーで自分がフォロワーでない
-			if (data.body.visibility === 'followers' && !Object.hasOwn(this.following, data.body.userId)) {
-				return;
+			// 公開範囲がフォロワーで、フォロワーでも例外 (自分の投稿へのリプライ / 自分へのメンション) でもない
+			if (data.body.visibility === 'followers') {
+				const meId = this.user?.id ?? null;
+				if (meId == null) return;
+
+				const isFollower = Object.hasOwn(this.following, data.body.userId);
+				// 自分の投稿に対するリプライ
+				const isReplyToMe = data.body.replyUserId === meId;
+				// 自分へのメンション
+				const isMentioningMe = data.body.mentions.includes(meId);
+
+				if (!isFollower && !isReplyToMe && !isMentioningMe) {
+					return;
+				}
 			}
 		}
 

--- a/packages/backend/src/server/api/stream/channel.ts
+++ b/packages/backend/src/server/api/stream/channel.ts
@@ -66,7 +66,8 @@ export default abstract class Channel {
 	}
 
 	protected isNoteVisibleForMe(note: Packed<'Note'>): boolean {
-		// This code must always be synchronized with the checks in QueryService.generateVisibilityQuery.
+		// This code must always be synchronized with the checks in QueryService.generateVisibilityQuery
+		// and Connection.onNoteStreamMessage.
 		const meId = this.connection.user?.id ?? null;
 
 		// visibility が specified かつ自分が指定されていなかったら非表示

--- a/packages/backend/test/e2e/streaming.ts
+++ b/packages/backend/test/e2e/streaming.ts
@@ -126,6 +126,84 @@ describe('Streaming', () => {
 			});
 		});
 
+		describe('subNote (noteUpdated)', () => {
+			// connectStream は channel メッセージ専用なので、subNote の購読はここで生の WebSocket を使う。
+			// subNote には ack が無いため、後続の connect の 'connected' を待って登録完了を保証する
+			// (サーバーは同一接続のメッセージを到着順に処理する)。
+			const waitNoteUpdated = async (user: misskey.entities.SignupResponse, noteId: string, trgr: () => any) => {
+				const ws = new WebSocket(`ws://127.0.0.1:${port}/streaming?i=${user.token}`);
+
+				try {
+					let onSubscribed: () => void;
+					const subscribed = new Promise<void>((resolve) => { onSubscribed = resolve; });
+
+					const received = new Promise<boolean>((resolve) => {
+						ws.on('message', data => {
+							const msg = JSON.parse(data.toString());
+							if (msg.type === 'connected' && msg.body.id === 'subNote-ack') {
+								onSubscribed!();
+							} else if (msg.type === 'noteUpdated' && msg.body.id === noteId) {
+								resolve(true);
+							}
+						});
+					});
+
+					await new Promise<void>((resolve, reject) => {
+						ws.on('open', () => resolve());
+						ws.on('error', reject);
+					});
+
+					ws.send(JSON.stringify({ type: 'subNote', body: { id: noteId } }));
+					ws.send(JSON.stringify({ type: 'connect', body: { channel: 'main', id: 'subNote-ack' } }));
+					await subscribed;
+
+					await trgr();
+
+					return await Promise.race([
+						received,
+						new Promise<void>((r) => setTimeout(() => r(), 3000)).then(() => false),
+					]);
+				} finally {
+					ws.close();
+				}
+			};
+
+			// erin は kanako をフォローしていない
+			test('followers 限定ノートで自分がメンションされていれば noteUpdated が届く', async () => {
+				const note = await post(kanako, { text: '@erin followers only', visibility: 'followers' });
+
+				const fired = await waitNoteUpdated(erin, note.id,
+					() => api('notes/reactions/create', { noteId: note.id, reaction: '\u{1f44d}' }, kanako),
+				);
+
+				assert.strictEqual(fired, true);
+			});
+
+			// ⚠ NoteCreateService はローカルのリプライ先ユーザーを mentions にも積む (NoteCreateService.ts:621)
+			// ため、このケースは mentions 例外でも通る。branch を単離してはいないが、
+			// 「リプライ先の当人に noteUpdated が届く」という要求そのものは見ている。
+			test('followers 限定ノートが自分の投稿へのリプライなら noteUpdated が届く', async () => {
+				const erinNote = await post(erin, { text: 'hello' });
+				const note = await post(kanako, { text: 'reply', replyId: erinNote.id, visibility: 'followers' });
+
+				const fired = await waitNoteUpdated(erin, note.id,
+					() => api('notes/reactions/create', { noteId: note.id, reaction: '\u{1f44d}' }, kanako),
+				);
+
+				assert.strictEqual(fired, true);
+			});
+
+			test('followers 限定ノートでフォロワーでもリプライ先でもメンション先でもなければ noteUpdated が届かない', async () => {
+				const note = await post(kanako, { text: 'followers only', visibility: 'followers' });
+
+				const fired = await waitNoteUpdated(erin, note.id,
+					() => api('notes/reactions/create', { noteId: note.id, reaction: '\u{1f44d}' }, kanako),
+				);
+
+				assert.strictEqual(fired, false);
+			});
+		});
+
 		describe('Home Timeline', () => {
 			test('自分の投稿が流れる', async () => {
 				const fired = await waitFire(


### PR DESCRIPTION
Fixes #422

## 何が起きていたか

`Connection.onNoteStreamMessage` の公開範囲チェックが `Channel.isNoteVisibleForMe` /
`QueryService.generateVisibilityQuery` と同期しておらず、followers 限定ノートを
**正当に閲覧できるユーザーが `noteUpdated` を受け取れない**。

`isNoteVisibleForMe` は followers 限定に 3 つの例外を認めている。

| 例外 | `onNoteStreamMessage` では |
| --- | --- |
| 投稿者自身 | ✅ 外側の `data.body.userId !== this.user?.id` で救われていた |
| 自分の投稿へのリプライ | 🔴 **漏れ** |
| 自分へのメンション | 🔴 **漏れ** |

REST では見えているのにストリームだけ更新が来ない、という**配信漏れ**（閲覧権限の無い
ユーザーへの過剰配信ではない）。ノート詳細を開いたまま編集やリアクションが起きても画面が変わらず、
リロードすると新しい状態が見える、という症状になる。

`channel.ts:69` の

```ts
// This code must always be synchronized with the checks in QueryService.generateVisibilityQuery.
```

に対して、`onNoteStreamMessage` は**同期対象に入っていない 3 つ目の複製**だった。

## 直し方

判定に必要な `replyUserId` / `mentions` が noteStream の payload に入っていなかったので、
まずそこから足している。

1. **`GlobalEventService`** — `NoteStreamEventTypes` と `publishNoteStream` に
   `replyUserId` / `mentions` を追加
2. **`Connection.onNoteStreamMessage`** — followers 限定の判定を `isNoteVisibleForMe` と同じ 3 例外に揃える
3. **`channel.ts`** — 「同期を保て」コメントの参照先に `Connection.onNoteStreamMessage` を追記。
   3 箇所目の複製であることが次に触る人に分かるようにする

⚠ `publishNoteStream` の呼び出し元 5 箇所 (`PollService` / `notes/polls/vote` / `NoteDeleteService` /
`ReactionService` ×2) は、いずれも `select:` で絞っていない完全な `MiNote` を渡しているので、
追加フィールドには実際に値が入る。

## 上流について

⚠ `Connection.ts` は **upstream と byte 単位で同一**（`git diff upstream/develop:... HEAD:...` が空）で、
これは upstream (misskey-dev/misskey) のバグでもある。ただし**方針により上流へは送らない**。

## レビュー反映 (Codex P1)

> During a rolling deployment, or when `MK_ONLY_SERVER` and `MK_ONLY_QUEUE` processes are upgraded separately, a new streaming process can receive a `noteStream` event from an old producer that has neither `mentions` nor `replyUserId`

**成立する。**pub/sub はプロセスを跨ぐので、新しい streaming プロセスが旧 producer の payload を
受け取りうる (例: 旧 queue プロセスの `ApInboxService.like` → `ReactionService.create` → `publishNoteStream`。
経路はコードで確認した)。`data.body.mentions.includes(meId)` は eager 評価なので TypeError になり、
async リスナーの unhandled rejection として落ちる。⚠ **`isFollower` が true でも先に評価されるため、
本来届くべきフォロワーにも届かなくなる。**

`c11b500df3` で `NoteStreamEventTypes` の 2 フィールドを optional にし、購読側で不在を扱うようにした。
⚠ **型を optional にしたことでコンパイラがガードを強制する** — `?.` を外すと `TS18048` で落ちる。
同じ穴が黙って再発しない形になった。

⚠ **このフォークの実機では現状この窓は無い。**`misskey.service` 単体構成で、デプロイも
stop → build → start（chubo2 の `docs/infra-misskey.md`）。`MK_ONLY_SERVER` / `MK_ONLY_QUEUE` の
分離運用もしていない。ただし Misskey 一般の構成では成立し、ガードのコストが無いので入れた。

## e2e テストを追加した

⚠ **コミットの粒度がずれている。**`c11b500df3` はメッセージに書いていないが、
下記の e2e テスト 78 行も同梱している (`git add -A` で巻き込んだ)。
プッシュ済みコミットの amend は AGENTS.md #6 で禁じているので書き換えず、ここに明示する。

`packages/backend/test/e2e/streaming.ts` に `describe('subNote (noteUpdated)')` を追加した。

| テスト | 見るもの |
| --- | --- |
| followers 限定で自分がメンションされていれば届く | mentions 例外 |
| followers 限定が自分の投稿へのリプライなら届く | リプライ例外 (下記の注意あり) |
| フォロワーでもリプライ先でもメンション先でもなければ届かない | 過剰配信していないこと |

⚠ `connectStream` は channel メッセージ専用なので、`subNote` の購読はローカルヘルパーで
生の WebSocket を使う。`subNote` に ack が無いため、**後続の `connect` の `connected` を待って
購読登録の完了を保証**している (サーバーは同一接続のメッセージを到着順に処理する)。

⚠ リプライのケースは、`NoteCreateService` がローカルのリプライ先ユーザーを `mentions` にも積む
(`NoteCreateService.ts:621`) ため **mentions 例外でも通る**。branch を単離してはいないが、
「リプライ先の当人に `noteUpdated` が届く」という要求そのものは見ている。

## 検証

⚠ このリポジトリには `node_modules` が無く `pnpm lint` / backend テストが回せない
（backend テストはそもそもこのフォークの CI にも無い）。代わりに**型で効かせられる部分を実証**した。

- `Serialized` / `EventUnionFromDictionary` / `SerializedAll` / `UndefinedAsNullAll` を verbatim で写した
  最小再現に、変更後の判定コードをそのまま置いて `tsc --strict` (7.0.2) → **エラー 0**
- ⚠⚠ **negative control も取った。** `NoteStreamEventTypes` から追加フィールドを外すと
  `TS2339: Property 'replyUserId' does not exist on ...` で落ちる。
  つまり上のチェックは実際に型を解決したうえで通っている（「型が解決されていない tsc は何も見ていない」を回避）
- `packages/backend/**` を触るので、この PR で `check-misskey-js-autogen`（#431 で復活させたもの）が実際に走る

### 🔴 追加した e2e テストはまだ一度も実行できていない

⚠ 手元には `node_modules` が無く、このフォークの CI にも backend テストのジョブが無い。
ステージング (dev27) で実行する方針だが、**dev27 に docker が入っていない**ため保留中
（pooza/chubo2#213 で依頼済み）。

⚠⚠ **docker が入っても、実機の稼働ツリーでは走らせられない。**
`packages/backend/scripts/compile_config.js` は読む YAML を `NODE_ENV` で切り替えるが
**出力先が `<repo>/built/.config.json` に固定**で、`test:e2e` は内部で
`NODE_ENV=test compile-config` を呼ぶ。稼働ツリーで回すと
**次の `systemctl restart misskey` でステージングがテスト設定で起動する**（時限式）。
ビルド成果物は分離されている (`build:e2e` → `built-test/`) ので、**設定だけが共有**という
気付きにくい形。別クローンで回す必要がある。

**このテストは緑を確認するまで「書いただけ」の状態。**マージ判断はその前提でお願いします。

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment (⚠ 上記のとおり型検証のみ)
- [ ] Test working in a Docker environment (該当なし)
- [ ] Add story of storybook (該当なし)
- [ ] Update CHANGELOG.md (⚠ 上流へ送らないフォーク内修正なので追記しない。`CHANGELOG.md` は upstream 所有で、追従のたびに衝突する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJoz6ujdFvBJ24sdm795Fd
