### PR TITLE
docs: upstream 由来の禁止事項をフォークの実態に合わせて注記する (#434)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,9 +39,9 @@
 
 ### Git / リポジトリ操作
 
-- `git push --force` / `--force-with-lease` を `main` / `develop` / `master` にしない
-- `git commit --no-verify` で hook をスキップしない
-- マージ済 / プッシュ済コミットを `git commit --amend` で書き換えない
+- `git push --force` / `--force-with-lease` を `daisskey` / `develop` / `main` / `master` にしない (⚠ `daisskey` がこのフォークのデフォルトブランチ。`main` は存在しない)
+- `git commit --no-verify` で hook をスキップしない (⚠ 現状このフォークに実効的な git hook は無く空振りする)
+- マージ済 / プッシュ済コミットを `git commit --amend` で書き換えない (⚠ 例外は「push 直後・レビュー前の未マージ PR ブランチ」だけ。レビュー後とマージ後は禁止)
 - 他人のブランチを `git reset --hard` / `git branch -D` で破壊しない
 - `git config` をユーザーに無断で書き換えない (特に `user.name` / `user.email` / `commit.gpgsign`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@
 
 違反すると CI 失敗 / 本番事故 / 共有環境破壊 になる。順守すること。
 
+⚠ **この 16 項目は upstream (misskey-dev/misskey) 由来**で、upstream の前提 (多人数・`main` / `develop` 運用) で書かれている。**フォークの実態に合わない箇所には `⚠ フォーク:` で始まる注記を付けてある**ので、原文と注記の両方を読むこと (#434)。
+
 ### コード・データ関連
 
 1. **SPDX ヘッダー欠落のまま AGPL 管轄ディレクトリへ新規ファイルを追加しない**
@@ -58,10 +60,14 @@
 
 ### Git / リポジトリ操作
 
-4. **`git push --force` / `--force-with-lease` を `main` / `develop` / `master` にしない** (他人の作業を消す可能性)
+4. **`git push --force` / `--force-with-lease` を `daisskey` / `develop` / `main` / `master` にしない** (他人の作業を消す可能性)
+   - ⚠ フォーク: **`daisskey` がこのフォークのデフォルトブランチ**で、`main` は存在しない。upstream の原文は `main` / `develop` / `master` の列挙で、**最も壊してはいけない `daisskey` が保護から漏れていた** (#434)
 5. **`git commit --no-verify` で hook をスキップしない** (lint / format / SPDX チェックを潰す)
+   - ⚠ フォーク: 2026-09-04 時点で**実効的な git hook は無い** (`.git/hooks/` は sample のみ、`core.hooksPath` 未設定、husky / lefthook も未導入)。**現状この条項は空振りする**が、hook を入れたときに効くよう残す
 6. **マージ済 / プッシュ済コミットを `git commit --amend` で書き換えない** (履歴の整合性が壊れる)
+   - ⚠ フォーク: **例外は「自分が push した直後の、レビューがまだ付いていない未マージ PR ブランチ」だけ。**単独コントリビューターで他人が fetch していないため、壊れる整合性が無い。⚠⚠ **レビューが付いた後とマージ後は従来どおり禁止**（指摘の宛先コミットが消える）
 7. **他人のブランチを `git reset --hard` / `git branch -D` で破壊しない**
+   - ⚠ フォーク: 単独コントリビューターなので現状は空振り。upstream へ持ち帰る可能性を考えて残す
 8. **`git config` をユーザーに無断で書き換えない** (特に `user.name` / `user.email` / `commit.gpgsign`)
 
 ### Issue / PR / 外部送信


### PR DESCRIPTION
Fixes #434（⚠ #12 を除く。下記参照）

## 🔴 本命: `daisskey` が force-push の保護から漏れていた

```diff
-4. **`git push --force` / `--force-with-lease` を `main` / `develop` / `master` にしない**
+4. **`git push --force` / `--force-with-lease` を `daisskey` / `develop` / `main` / `master` にしない**
```

upstream の原文は**ブランチ名を直書きで列挙**している。このフォークのデフォルトブランチは `daisskey` で
`main` は存在しないため、**最も壊してはいけないブランチが保護対象に入っていなかった。**

⚠ `main` を使っていないのは「フォークであることの明示」という設計意図だが、
upstream 側が名前で列挙する書き方をしているせいで、**その意図がそのまま穴になっていた。**
`main` / `master` も残したのは、将来もし名前が変わっても保護が外れないようにするため（保護対象は上位集合でよい）。

## その他の注記

16 項目は**全て upstream 由来**（`f6ea52b1be` / `3693adbb2d`）で、upstream の前提のまま書かれている。
実態に合わない箇所に **`⚠ フォーク:` で始まる注記**を付けた（原文は消していない）。

| # | 注記の内容 |
| --- | --- |
| 5 | **実効的な git hook が無い**（`.git/hooks/` は sample のみ、`core.hooksPath` 未設定、husky / lefthook も未導入）ので**現状は空振りする**。hook を入れたときに効くよう条項は残す |
| 6 | 例外は**「push 直後・レビュー前の未マージ PR ブランチ」だけ**。⚠⚠ **レビュー後とマージ後は従来どおり禁止**（指摘の宛先コミットが消えるため） |
| 7 | 単独コントリビューターなので現状は空振り。upstream へ持ち帰る可能性を考えて残す |

セクション冒頭にも「16 項目は upstream 由来で、フォーク注記は `⚠ フォーク:` で始まる」ことを書いた。
原文と注記の両方を読ませるため。

⚠ #6 の注記は**実際に踏んだ問題**への対処。PR #432 でコミットに意図しないファイルを巻き込んだ際、
この条項を理由に amend を避けて**コミットメッセージと中身がずれたまま**にした。
規約が実態に合っていないと、こういう不合理な回避が起きる。

## ⚠ #12（脆弱性報告の宛先）は含めない

フォーク独自コード（`WidgetTagset` 等）の脆弱性をどこへ出すかは**方針判断が要る**ので #434 に残した。
現状 `creating-issues-and-prs` スキルが案内するのは misskey-dev の security policy だけ。

参考: このリポジトリの **private vulnerability reporting は無効**（`repos/pooza/misskey/private-vulnerability-reporting` → `{"enabled": false}`）。
有効にすれば GitHub 標準の非公開報告窓口が使えるが、設定変更なのでオーナーの判断待ち。

## 検証

- 変更は `.md` 2 ファイルのみ。eslint / tsc の対象外
- `locales/` は未変更（locale safety チェック済み）
- `.github/copilot-instructions.md` は AGENTS.md の Copilot 向け再掲なので同期した

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment (該当なし・ドキュメントのみ)
- [ ] Test working in a Docker environment (該当なし)
- [ ] Add story of storybook (該当なし)
- [ ] Update CHANGELOG.md (⚠ フォーク内の規約整備なので追記しない。`CHANGELOG.md` は upstream 所有で追従のたびに衝突する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJoz6ujdFvBJ24sdm795Fd
