### PR TITLE
fix: SPDX ヘッダーのチェックを CI に戻す (#433)

### DIFF
--- a/.github/workflows/check-spdx-license-id.yml
+++ b/.github/workflows/check-spdx-license-id.yml
@@ -1,0 +1,65 @@
+name: Check SPDX-License-Identifier
+
+# AGENTS.md「絶対にやってはいけない事」#1 (AGPL 管轄への新規ファイルは SPDX ヘッダー必須) を
+# CI で担保する (#433)。
+#
+# ⚠ upstream 版は移植していない。upstream の現行版は scripts/check-spdx.mjs を呼ぶが
+# そのスクリプトはこのフォークのツリーに無く (2026.7.0 に含まれていなかった)、
+# 2026.7.0 版は find ベースの 70 行の bash。ここは git ls-files ベースで書き直してある。
+# 実測 0.03 秒 / 2255 ファイル。install もビルドも不要。
+
+on:
+  pull_request:
+    paths:
+      - '**.ts'
+      - '**.js'
+      - '**.cjs'
+      - '**.mjs'
+      - '**.vue'
+      - '**.scss'
+      - '**.html'
+      - .github/workflows/check-spdx-license-id.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check SPDX-License-Identifier
+        run: |
+          # ⚠ packages/misskey-js は MIT のサブパッケージなので対象に入れない
+          dirs=(
+            packages/backend/migration packages/backend/src packages/backend/test
+            packages/frontend-shared/@types packages/frontend-shared/js packages/frontend-builder
+            packages/frontend/.storybook packages/frontend/@types packages/frontend/lib
+            packages/frontend/public packages/frontend/src packages/frontend/test
+            packages/frontend-embed/@types packages/frontend-embed/src
+            packages/icons-subsetter/src packages/misskey-bubble-game/src
+            packages/misskey-reversi/src packages/sw/src scripts
+          )
+
+          missing="$(
+            git ls-files -z -- "${dirs[@]}" \
+              | grep -zE '\.(ts|js|cjs|mjs|vue|scss|html)$' \
+              | grep -zvE '\.config\.(ts|js|cjs|mjs)$|eslint' \
+              | xargs -0 -r grep -L 'SPDX-License-Identifier' || true
+          )"
+
+          if [ -n "$missing" ]; then
+            while IFS= read -r f; do echo "Missing: $f"; done <<< "$missing"
+            echo "::error::SPDX-License-Identifier が $(echo "$missing" | wc -l) 件のファイルに欠落しています。AGENTS.md #1 のヘッダーを先頭に追加してください (.vue / .html は HTML コメント形式)。"
+            exit 1
+          fi
+
+          echo "SPDX: OK"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,9 @@
 
 1. **SPDX ヘッダー欠落のまま AGPL 管轄ディレクトリへ新規ファイルを追加しない**
    - 対象: 新規 `.ts` / `.js` / `.cjs` / `.mjs` / `.vue` / `.scss` / `.html` ファイル
-   - CI の対象判定は [.github/workflows/check-spdx-license-id.yml](.github/workflows/check-spdx-license-id.yml) の `directories` 配列を参照 (`*.config.{ts,js,cjs,mjs}` と `*eslint*` は除外)
-   - 欠落すると CI (`spdx` ジョブ) が失敗する
+   - CI の対象判定は [.github/workflows/check-spdx-license-id.yml](.github/workflows/check-spdx-license-id.yml) の `dirs` 配列を参照 (`*.config.{ts,js,cjs,mjs}` と `*eslint*` は除外)
+   - 欠落すると CI (`Check SPDX-License-Identifier`) が失敗する
+   - ⚠ フォーク: **この workflow はフォーク自前の実装** (#433)。upstream 現行版が呼ぶ `scripts/check-spdx.mjs` はこのツリーに無いので、追従時にそのまま持ってこないこと
    - `packages/misskey-js` は MIT ライセンスのサブパッケージなので、この AGPL ヘッダーを一律に付けない (サブパッケージ固有の `package.json` / `LICENSE` / 既存ファイルのヘッダーに従う)
 
    `.ts` / `.js` / `.cjs` / `.mjs` / `.scss`:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -220,8 +220,8 @@ API 仕様の正本は
 （唯一の lint/test ジョブ `packages-private.yml` は `packages-private/` のみが対象）。
 
 ⚠⚠ **削るときは、残した側が参照しているファイルまで落ちていないか確かめる。**
-2026-09-04 時点で走る workflow は `packages-private.yml` と
-`check-misskey-js-autogen.yml` の 2 本。
+2026-09-04 時点で走る workflow は `packages-private.yml` /
+`check-misskey-js-autogen.yml` / `check-spdx-license-id.yml` の 3 本。
 診断系 4 本（backend / frontend diagnostics の inspect / comment）は
 `.github/misskey/test.yml` を `cp` するのにその設定ファイルがツリーに無く、
 **`inspect` は毎回 failure・`comment` は毎回 skipped のまま放置されていた**ので削除した（#428）。
@@ -252,6 +252,16 @@ API 仕様の正本は
 **fork の PR トークンではコメントできない upstream 事情のための 2 本立て（producer + comment）は採らず**、
 このリポジトリの PR は同一リポジトリのブランチから出るので
 **1 本の workflow が直接 fail する形に単純化し、宙に浮いた comment 側は削除した**。
+
+**`check-spdx-license-id` はフォーク自前で書き直した（#433）。** AGENTS.md #1（AGPL 管轄への新規
+ファイルは SPDX ヘッダー必須）を CI が検査する。⚠ **2026-09-04 まではこれも死んでいた** —
+`e6e765bc6f`「del: actionsをクリア。」で消えたまま、AGENTS.md には「CI (`spdx` ジョブ) が失敗する」
+と書いてあった。
+
+⚠⚠ **upstream 版は移植していない。**upstream の現行版は `scripts/check-spdx.mjs` を呼ぶが、
+**そのスクリプトはこのツリーに無い**（2026.7.0 に含まれていなかった）。2026.7.0 版は `find` ベースの
+70 行の bash。フォーク版は `git ls-files` ベースで書き直してあり、**実測 0.03 秒 / 2255 ファイル、
+`pnpm install` もビルドも不要**。⚠ 追従時に upstream 版をそのまま持ってこないこと。
 
 🔴 **これは capsicum に波及する。** capsicum は
 [docs/misskey-capsicum-api-watch.md](https://github.com/pooza/capsicum/blob/main/docs/misskey-capsicum-api-watch.md)


### PR DESCRIPTION
Fixes #433

## 方針: upstream 版は移植していない

⚠ **upstream の実装をそのまま持ってくることはできない。**

| | 実装 | このフォークで使えるか |
| --- | --- | --- |
| upstream 現行 | `node scripts/check-spdx.mjs --ci` | 🔴 **不可**。`scripts/check-spdx.mjs` がツリーに無い（2026.7.0 に含まれていなかった） |
| upstream 2026.7.0 | `find` ベースの 70 行の bash | 動くが冗長 |
| **本 PR** | `git ls-files` ベース、実質 10 行 | ✅ |

対象ディレクトリと除外規則（`*.config.{ts,js,cjs,mjs}` / `*eslint*` / `packages/misskey-js` は
MIT サブパッケージなので対象外）は **upstream 2026.7.0 の `directories` 配列と同じ**にしてある。

## コスト

**`pnpm install` もビルドも要らない。**checkout してファイルを走査するだけ。

```console
$ time bash <埋め込みスクリプトそのまま>
SPDX: OK
bash  0.01s user 0.03s system 112% cpu 0.031 total
```

⚠ **2255 ファイルで 0.03 秒。**復活させた `check-misskey-js-autogen`（install + ビルドで 60 秒）とは
コストの桁が違う。paths フィルタも付けてあるので、該当拡張子を触った PR でしか走らない。

## 検証

- ✅ **positive**: 埋め込んだスクリプトをそのままローカルで実行して `SPDX: OK`。**既存ファイルに欠落は無い**
- ✅ **negative control**: ヘッダー無しの `.ts` を `packages/backend/src/` に置くと
  `Missing: packages/backend/src/__spdx_probe.ts` を出して exit 1（確認後に削除済み）
- ✅ `actionlint` 1.7.12（+ shellcheck）がクリーン

## 記述も実態に合わせた

- **AGENTS.md #1** — 参照先を `dirs` 配列に、ジョブ名を実際のものに修正。
  ⚠ **追従時に upstream 版をそのまま持ってこない**旨を注記
- **docs/CLAUDE.md** — 走る workflow を 3 本に更新し、フォーク自前で書き直した理由を追記
- `.github/copilot-instructions.md:15` は「詳細な対象判定は `check-spdx-license-id.yml` を参照」と
  書いてあり、**この PR で再び正しくなる**ので変更不要

## ⚠ #434 / PR #435 との関係

同じ `AGENTS.md` を触るが**ハンクが別**（本 PR は #1、#435 は #4〜#7 とセクション冒頭）なので衝突しない。
どちらから merge しても構わない。

## Checklist

- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment (埋め込みスクリプトを positive / negative 両方で実行)
- [ ] Test working in a Docker environment (該当なし)
- [ ] Add story of storybook (該当なし)
- [ ] Update CHANGELOG.md (⚠ フォーク内の CI 整備なので追記しない。`CHANGELOG.md` は upstream 所有で追従のたびに衝突する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJoz6ujdFvBJ24sdm795Fd
